### PR TITLE
Tracking station performance fix

### DIFF
--- a/KerbalSlingshotter/SlingshotCore.cs
+++ b/KerbalSlingshotter/SlingshotCore.cs
@@ -23,8 +23,16 @@ namespace KerbalSlingshotter
 
     [KSPAddon(KSPAddon.Startup.TrackingStation,false)]
     public class TrackingSlingshot : SlingshotCore {
+        private SpaceTracking st;
+
+        new public void Start()
+        {
+            base.Start();
+
+            st = (SpaceTracking)FindObjectOfType(typeof(SpaceTracking));
+        }
+
         protected override Vessel CurrentVessel() {
-            SpaceTracking st = (SpaceTracking)FindObjectOfType(typeof(SpaceTracking));
             if (st.MainCamera.target != null && st.MainCamera.target.type == MapObject.ObjectType.Vessel)
             {
                 return st.MainCamera.target.vessel;

--- a/KerbalSlingshotter/SlingshotCore.cs
+++ b/KerbalSlingshotter/SlingshotCore.cs
@@ -32,7 +32,6 @@ namespace KerbalSlingshotter
     {
         internal static Texture2D ShipIcon = null;
         internal static Texture2D BodyIcon = null;
-        private static Vessel vessel { get { return CurrentVessel(); } }
         protected Rect windowPos = new Rect(50, 100, 300, 400);
         double DesiredTime;
         TimeInfo desiredTimeInfo = new TimeInfo();
@@ -81,6 +80,7 @@ namespace KerbalSlingshotter
 
         void FixedUpdate()
         {
+            Vessel vessel = CurrentVessel();
             if (vessel == null || vessel.patchedConicSolver == null)
                 return;
             // Following needed to adjust values for slider, which can only use float
@@ -187,8 +187,9 @@ namespace KerbalSlingshotter
             scrollbar_stlye.margin = new RectOffset(1, 1, 1, 1);
             scrollbar_stlye.overflow = new RectOffset(1, 1, 1, 1);
 
-            
 
+
+            Vessel vessel = CurrentVessel();
             if (vessel.patchedConicSolver.maneuverNodes.Any())
             {
                 GUILayout.BeginHorizontal();
@@ -317,6 +318,7 @@ namespace KerbalSlingshotter
 
         void DrawNodeOrbits()
         {
+            Vessel vessel = CurrentVessel();
             Orbit o = vessel.orbit;
             foreach (ManeuverNode node in vessel.patchedConicSolver.maneuverNodes)
             {
@@ -343,6 +345,7 @@ namespace KerbalSlingshotter
 
         void DrawIconForAllOrbits()
         {
+            Vessel vessel = CurrentVessel();
             if (vessel != null)
             {
                 DrawPatchIcons(vessel.orbit); // Icons for all patches of actual vessel orbit
@@ -396,6 +399,7 @@ namespace KerbalSlingshotter
 
         void ToggleOn()
         {
+            Vessel vessel = CurrentVessel();
             if (vessel != null) WindowVisible = true;
         }
         void ToggleOff()

--- a/KerbalSlingshotter/SlingshotCore.cs
+++ b/KerbalSlingshotter/SlingshotCore.cs
@@ -33,9 +33,11 @@ namespace KerbalSlingshotter
         }
 
         protected override Vessel CurrentVessel() {
-            if (st.MainCamera.target != null && st.MainCamera.target.type == MapObject.ObjectType.Vessel)
+            MapObject target = st?.MainCamera?.target;
+
+            if (target != null && target.type == MapObject.ObjectType.Vessel)
             {
-                return st.MainCamera.target.vessel;
+                return target.vessel;
             }
             else
             {

--- a/KerbalSlingshotter/SlingshotCore.cs
+++ b/KerbalSlingshotter/SlingshotCore.cs
@@ -15,10 +15,26 @@ using ToolbarControl_NS;
 namespace KerbalSlingshotter
 {
     [KSPAddon(KSPAddon.Startup.Flight,false)]
-    public class FlightSlingshot : SlingshotCore { }
+    public class FlightSlingshot : SlingshotCore {
+        protected override Vessel CurrentVessel() {
+            return FlightGlobals.ActiveVessel;
+        }
+    }
 
     [KSPAddon(KSPAddon.Startup.TrackingStation,false)]
-    public class TrackingSlingshot : SlingshotCore { }
+    public class TrackingSlingshot : SlingshotCore {
+        protected override Vessel CurrentVessel() {
+            SpaceTracking st = (SpaceTracking)FindObjectOfType(typeof(SpaceTracking));
+            if (st.MainCamera.target != null && st.MainCamera.target.type == MapObject.ObjectType.Vessel)
+            {
+                return st.MainCamera.target.vessel;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
 
     public class TimeInfo
     {
@@ -28,7 +44,7 @@ namespace KerbalSlingshotter
             minutes = 0,
             seconds = 0;
     }
-    public class SlingshotCore : MonoBehaviour
+    public abstract class SlingshotCore : MonoBehaviour
     {
         internal static Texture2D ShipIcon = null;
         internal static Texture2D BodyIcon = null;
@@ -45,6 +61,8 @@ namespace KerbalSlingshotter
         ToolbarControl toolbarControl;
         bool WindowVisible = false;
        // uint years = 0, days = 0, hours = 0, minutes = 0, seconds = 0;
+
+        protected abstract Vessel CurrentVessel();
 
         public void Start()
         {
@@ -127,29 +145,6 @@ namespace KerbalSlingshotter
                 lastVessel = vessel;
             }
         }
-
-        static Vessel CurrentVessel()
-        {
-            if (HighLogic.LoadedScene == GameScenes.FLIGHT && FlightGlobals.ActiveVessel != null)
-            {
-                return FlightGlobals.ActiveVessel;
-            }
-            else if (HighLogic.LoadedScene == GameScenes.TRACKSTATION)
-            {
-
-                SpaceTracking st = (SpaceTracking)FindObjectOfType(typeof(SpaceTracking));
-                if (st.MainCamera.target != null && st.MainCamera.target.type == MapObject.ObjectType.Vessel)
-                {
-                    return st.MainCamera.target.vessel;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            return null;
-        }
-
 
         TimeInfo setTimeSelection(double selection)
         {


### PR DESCRIPTION
I looked into Slingshotter's framerate impact in the tracking station, and found that it's caused by calling Unity's [`FindObjectOfType`](https://docs.unity3d.com/ScriptReference/Object.FindObjectOfType.html) method every frame (and usually multiple times per frame), which isn't recommended because that method is quite slow.  I've done some refactoring to avoid that: now the lookup happens just once while starting the tracking station scene, and performance is smooth even when the Slingshotter window is open.